### PR TITLE
feat: 常识分类变量 + UI交互优化 + 冒号修复

### DIFF
--- a/Source/API/KnowledgeVariableProvider.cs
+++ b/Source/API/KnowledgeVariableProvider.cs
@@ -7,6 +7,7 @@ using Verse;
 using RimWorld;
 using RimTalk.MemoryPatch;
 using RimTalk.Memory;
+using RimTalk.Memory.UI;
 
 namespace RimTalk.Memory.API
 {
@@ -161,6 +162,220 @@ namespace RimTalk.Memory.API
                 return "";
             }
         }
+
+        /// <summary>
+        /// 获取按分类分组的常识内容（改进版 {{knowledge}}）
+        /// 输出格式：按分类分组，每组有标题，条目只显示分类标签
+        /// </summary>
+        public static string GetGroupedKnowledge(object promptContext)
+        {
+            if (promptContext == null) return "";
+
+            try
+            {
+                var matchedScores = GetMatchedScores(promptContext);
+                if (matchedScores == null || matchedScores.Count == 0)
+                    return "(No matching knowledge found)";
+
+                return FormatGroupedKnowledge(matchedScores);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"[MemoryPatch] Error getting grouped knowledge: {ex.Message}");
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// 获取指定分类的常识内容
+        /// </summary>
+        public static string GetKnowledgeByCategory(object promptContext, KnowledgeCategory category)
+        {
+            if (promptContext == null) return "";
+
+            try
+            {
+                var matchedScores = GetMatchedScores(promptContext);
+                if (matchedScores == null || matchedScores.Count == 0)
+                    return "";
+
+                var filtered = matchedScores
+                    .Where(s => CommonKnowledgeUIHelpers.GetEntryCategory(s.Entry) == category)
+                    .ToList();
+
+                if (filtered.Count == 0) return "";
+
+                return FormatCategoryEntries(filtered);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"[MemoryPatch] Error getting knowledge for category {category}: {ex.Message}");
+                return "";
+            }
+        }
+
+        // 分类变量的便捷包装方法
+        public static string GetKnowledgeRules(object ctx) => GetKnowledgeByCategory(ctx, KnowledgeCategory.Instructions);
+        public static string GetKnowledgeLore(object ctx) => GetKnowledgeByCategory(ctx, KnowledgeCategory.Lore);
+        public static string GetKnowledgeStatus(object ctx) => GetKnowledgeByCategory(ctx, KnowledgeCategory.PawnStatus);
+        public static string GetKnowledgeHistory(object ctx) => GetKnowledgeByCategory(ctx, KnowledgeCategory.History);
+        public static string GetKnowledgeOther(object ctx) => GetKnowledgeByCategory(ctx, KnowledgeCategory.Other);
+
+        // 缓存匹配结果，避免同一渲染周期内多次匹配
+        private static List<KnowledgeScore> _cachedScores;
+        private static int _cachedTick = -1;
+        private static readonly object _cacheLock = new object();
+        
+        /// <summary>
+        /// 核心匹配逻辑：获取匹配的常识评分列表（复用 GetMatchedKnowledge 的逻辑）
+        /// 同一 tick 内的多次调用会复用缓存结果
+        /// </summary>
+        private static List<KnowledgeScore> GetMatchedScores(object promptContext)
+        {
+            int currentTick = Find.TickManager?.TicksGame ?? 0;
+            
+            // 同一 tick 内复用缓存
+            lock (_cacheLock)
+            {
+                if (_cachedScores != null && _cachedTick == currentTick)
+                    return _cachedScores;
+            }
+            
+            var settings = RimTalkMemoryPatchMod.Settings;
+
+            string matchText = BuildMatchText(promptContext, settings);
+            if (string.IsNullOrEmpty(matchText))
+                return null;
+
+            Pawn speaker = GetPropertyValue<Pawn>(promptContext, "CurrentPawn");
+            Pawn listener = null;
+            var allPawns = GetPropertyValue<List<Pawn>>(promptContext, "AllPawns");
+            if (allPawns != null && allPawns.Count > 1)
+                listener = allPawns[1];
+
+            var memoryManager = Find.World?.GetComponent<MemoryManager>();
+            if (memoryManager?.CommonKnowledge == null)
+                return null;
+
+            List<KnowledgeScore> matchedScores;
+            memoryManager.CommonKnowledge.InjectKnowledgeWithDetails(
+                matchText,
+                settings.maxInjectedKnowledge,
+                out matchedScores,
+                speaker,
+                listener
+            );
+
+            // 同步更新 _lastContext（保持与 GetMatchedKnowledge 一致）
+            string dialogueType = GetVariableValue(promptContext, "dialogue.type");
+            lock (_contextLock)
+            {
+                _lastContext = new KnowledgeInjectionContext
+                {
+                    MatchText = matchText,
+                    DialogueType = dialogueType,
+                    KeywordKnowledge = FormatCategoryEntries(matchedScores),
+                    Speaker = speaker,
+                    Listener = listener,
+                    Tick = currentTick
+                };
+            }
+            
+            // 缓存结果
+            lock (_cacheLock)
+            {
+                _cachedScores = matchedScores;
+                _cachedTick = currentTick;
+            }
+
+            return matchedScores;
+        }
+
+        /// <summary>
+        /// 获取分类的中文显示名称
+        /// </summary>
+        private static string GetCategoryDisplayName(KnowledgeCategory category)
+        {
+            switch (category)
+            {
+                case KnowledgeCategory.Instructions: return "规则";
+                case KnowledgeCategory.Lore: return "世界观";
+                case KnowledgeCategory.PawnStatus: return "殖民者状态";
+                case KnowledgeCategory.History: return "历史";
+                case KnowledgeCategory.Other: return "其他";
+                default: return "未知";
+            }
+        }
+
+        /// <summary>
+        /// 获取条目的第一个标签（分类标签），用于简化显示
+        /// </summary>
+        private static string GetFirstTag(CommonKnowledgeEntry entry)
+        {
+            if (string.IsNullOrEmpty(entry.tag)) return "";
+            var tags = entry.GetTags();
+            return tags.Count > 0 ? tags[0] : entry.tag;
+        }
+
+        /// <summary>
+        /// 格式化分组输出（用于 {{knowledge}}）
+        /// </summary>
+        private static string FormatGroupedKnowledge(List<KnowledgeScore> scores)
+        {
+            if (scores == null || scores.Count == 0) return "";
+
+            // 按分类分组
+            var groups = new Dictionary<KnowledgeCategory, List<KnowledgeScore>>();
+            foreach (var score in scores)
+            {
+                var cat = CommonKnowledgeUIHelpers.GetEntryCategory(score.Entry);
+                if (!groups.ContainsKey(cat))
+                    groups[cat] = new List<KnowledgeScore>();
+                groups[cat].Add(score);
+            }
+
+            // 按固定顺序输出：规则 → 世界观 → 殖民者状态 → 历史 → 其他
+            var order = new KnowledgeCategory[]
+            {
+                KnowledgeCategory.Instructions,
+                KnowledgeCategory.Lore,
+                KnowledgeCategory.PawnStatus,
+                KnowledgeCategory.History,
+                KnowledgeCategory.Other
+            };
+
+            var sb = new StringBuilder();
+            foreach (var cat in order)
+            {
+                if (!groups.ContainsKey(cat)) continue;
+                var entries = groups[cat];
+
+                sb.AppendLine($"## {GetCategoryDisplayName(cat)}");
+                foreach (var score in entries)
+                {
+                    sb.AppendLine($"- {score.Entry.content}");
+                }
+                sb.AppendLine();
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        /// <summary>
+        /// 格式化单分类条目列表（用于 {{knowledge_xxx}} 变量）
+        /// </summary>
+        private static string FormatCategoryEntries(List<KnowledgeScore> scores)
+        {
+            if (scores == null || scores.Count == 0) return "";
+
+            var sb = new StringBuilder();
+            foreach (var score in scores)
+            {
+                sb.AppendLine($"- {score.Entry.content}");
+            }
+            return sb.ToString().TrimEnd();
+        }
+
         
         /// <summary>
         /// 根据用户选择的匹配源构建匹配文本

--- a/Source/API/RimTalkAPIIntegration.cs
+++ b/Source/API/RimTalkAPIIntegration.cs
@@ -1,9 +1,8 @@
-using RimTalk.API;
-using RimTalk.MemoryPatch;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Verse;
+using RimTalk.MemoryPatch;
 
 namespace RimTalk.Memory.API
 {
@@ -72,13 +71,9 @@ namespace RimTalk.Memory.API
                 RegisterPromptEntry();
                 
                 Log.Message("[MemoryPatch] ✓ Integrated via RimTalk API v4.0+");
-                Log.Message("[MemoryPatch]   - Registered {{pawn.memory}} variable (combined memories)");
-                Log.Message("[MemoryPatch]   - Registered {{pawn.ABM}} variable (active buffer - raw)");
-                Log.Message("[MemoryPatch]   - Registered {{pawn.ELS}} variable (event log - raw)");
-                Log.Message("[MemoryPatch]   - Registered {{pawn.CLPA}} variable (archive - raw)");
-                Log.Message("[MemoryPatch]   - Registered {{pawn.matchELS}} variable (event log - matched)");
-                Log.Message("[MemoryPatch]   - Registered {{pawn.matchCLPA}} variable (archive - matched)");
+                Log.Message("[MemoryPatch]   - Registered {{pawn.memory}} variable");
                 Log.Message("[MemoryPatch]   - Registered {{knowledge}} variable");
+                Log.Message("[MemoryPatch]   - Registered {{knowledge_grouped/rules/lore/status/history/other}} variables");
                 Log.Message("[MemoryPatch]   - Added PromptEntry: " + ENTRY_NAME);
             }
             catch (Exception ex)
@@ -152,7 +147,7 @@ namespace RimTalk.Memory.API
         /// </summary>
         private static void RegisterVariables()
         {
-            // 1. 注册 {{pawn.memory}} - Pawn 变量（综合记忆）
+            // 1. 注册 {{pawn.memory}} - Pawn 变量
             // 使用 Func<Pawn, string> 委托
             var registerPawnVar = _promptAPIType.GetMethod("RegisterPawnVariable");
             if (registerPawnVar != null)
@@ -163,10 +158,10 @@ namespace RimTalk.Memory.API
                     Func<Pawn, string> memoryProvider = MemoryVariableProvider.GetPawnMemory;
                     
                     // 调用 RegisterPawnVariable(modId, variableName, provider, description, priority)
-                    registerPawnVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "memory",
+                    registerPawnVar.Invoke(null, new object[] 
+                    { 
+                        MOD_ID, 
+                        "memory", 
                         memoryProvider,
                         "Character's personal memories and experiences",
                         100 // priority
@@ -181,162 +176,63 @@ namespace RimTalk.Memory.API
                 {
                     Log.Warning($"[MemoryPatch] Failed to register pawn.memory: {ex.Message}");
                 }
-                
-                // 2. 注册 {{pawn.ABM}} - ABM 层记忆（超短期记忆）
-                try
-                {
-                    Func<Pawn, string> abmProvider = MemoryVariableProvider.GetPawnABM;
-                    
-                    registerPawnVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "ABM",
-                        abmProvider,
-                        "Character's active buffer memories (recent conversations)",
-                        100
-                    });
-                    
-                    if (Prefs.DevMode)
-                    {
-                        Log.Message("[MemoryPatch] ✓ Registered {{pawn.ABM}} variable");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"[MemoryPatch] Failed to register pawn.ABM: {ex.Message}");
-                }
-                
-                // 3. 注册 {{pawn.ELS}} - ELS 层记忆（中期记忆）
-                try
-                {
-                    Func<Pawn, string> elsProvider = MemoryVariableProvider.GetPawnELS;
-                    
-                    registerPawnVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "ELS",
-                        elsProvider,
-                        "Character's event log summary (mid-term memories)",
-                        100
-                    });
-                    
-                    if (Prefs.DevMode)
-                    {
-                        Log.Message("[MemoryPatch] ✓ Registered {{pawn.ELS}} variable");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"[MemoryPatch] Failed to register pawn.ELS: {ex.Message}");
-                }
-                
-                // 4. 注册 {{pawn.CLPA}} - CLPA 层记忆（长期记忆）
-                try
-                {
-                    Func<Pawn, string> clpaProvider = MemoryVariableProvider.GetPawnCLPA;
-                    
-                    registerPawnVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "CLPA",
-                        clpaProvider,
-                        "Character's persona archive (long-term memories)",
-                        100
-                    });
-                    
-                    if (Prefs.DevMode)
-                    {
-                        Log.Message("[MemoryPatch] ✓ Registered {{pawn.CLPA}} variable");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"[MemoryPatch] Failed to register pawn.CLPA: {ex.Message}");
-                }
-                
-                // 5. 注册 {{pawn.matchELS}} - 匹配后的 ELS 层记忆
-                try
-                {
-                    Func<Pawn, string> matchElsProvider = MemoryVariableProvider.GetPawnMatchELS;
-                    
-                    registerPawnVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "matchELS",
-                        matchElsProvider,
-                        "Context-matched event log memories (mid-term)",
-                        100
-                    });
-                    
-                    if (Prefs.DevMode)
-                    {
-                        Log.Message("[MemoryPatch] ✓ Registered {{pawn.matchELS}} variable");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"[MemoryPatch] Failed to register pawn.matchELS: {ex.Message}");
-                }
-                
-                // 6. 注册 {{pawn.matchCLPA}} - 匹配后的 CLPA 层记忆
-                try
-                {
-                    Func<Pawn, string> matchClpaProvider = MemoryVariableProvider.GetPawnMatchCLPA;
-                    
-                    registerPawnVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "matchCLPA",
-                        matchClpaProvider,
-                        "Context-matched archive memories (long-term)",
-                        100
-                    });
-                    
-                    if (Prefs.DevMode)
-                    {
-                        Log.Message("[MemoryPatch] ✓ Registered {{pawn.matchCLPA}} variable");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"[MemoryPatch] Failed to register pawn.matchCLPA: {ex.Message}");
-                }
             }
             
-            // 7. 注册 {{knowledge}} - Context 变量
+            // 2. 注册 {{knowledge}} - Context 变量（保持原有格式不变）
             var registerCtxVar = _promptAPIType.GetMethod("RegisterContextVariable");
             if (registerCtxVar != null)
             {
-                try
-                {
-                    // 创建委托 - 使用 object 类型接收 MustacheContext
-                    // 因为我们无法直接引用 RimTalk 的类型
-                    Func<object, string> knowledgeProvider = KnowledgeVariableProvider.GetMatchedKnowledge;
-                    
-                    // 调用 RegisterContextVariable(modId, variableName, provider, description, priority)
-                    registerCtxVar.Invoke(null, new object[]
-                    {
-                        MOD_ID,
-                        "knowledge",
-                        knowledgeProvider,
-                        "World knowledge matched to conversation context",
-                        100 // priority
-                    });
-                    
-                    if (Prefs.DevMode)
-                    {
-                        Log.Message("[MemoryPatch] ✓ Registered {{knowledge}} variable");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"[MemoryPatch] Failed to register knowledge: {ex.Message}");
-                }
+                // 原有变量 {{knowledge}} — 保持 "1. [tag] content" 格式，兼容旧预设
+                RegisterOneContextVariable(registerCtxVar, "knowledge",
+                    new Func<object, string>(KnowledgeVariableProvider.GetMatchedKnowledge),
+                    "World knowledge matched to conversation context", 100);
+                
+                // 新增：按分类分组的完整输出
+                RegisterOneContextVariable(registerCtxVar, "knowledge_grouped",
+                    new Func<object, string>(KnowledgeVariableProvider.GetGroupedKnowledge),
+                    "World knowledge grouped by category headers", 101);
+                
+                // 新增：按分类拆分的独立变量
+                RegisterOneContextVariable(registerCtxVar, "knowledge_rules",
+                    new Func<object, string>(KnowledgeVariableProvider.GetKnowledgeRules),
+                    "Knowledge: rules and instructions", 102);
+                
+                RegisterOneContextVariable(registerCtxVar, "knowledge_lore",
+                    new Func<object, string>(KnowledgeVariableProvider.GetKnowledgeLore),
+                    "Knowledge: world lore and background", 103);
+                
+                RegisterOneContextVariable(registerCtxVar, "knowledge_status",
+                    new Func<object, string>(KnowledgeVariableProvider.GetKnowledgeStatus),
+                    "Knowledge: pawn/colonist status", 104);
+                
+                RegisterOneContextVariable(registerCtxVar, "knowledge_history",
+                    new Func<object, string>(KnowledgeVariableProvider.GetKnowledgeHistory),
+                    "Knowledge: historical events", 105);
+                
+                RegisterOneContextVariable(registerCtxVar, "knowledge_other",
+                    new Func<object, string>(KnowledgeVariableProvider.GetKnowledgeOther),
+                    "Knowledge: uncategorized", 106);
             }
         }
         
-        // Chat History 条目的名称
-        private const string CHAT_HISTORY_ENTRY_NAME = "Chat History";
+        /// <summary>
+        /// 注册单个 Context 变量的辅助方法
+        /// </summary>
+        private static void RegisterOneContextVariable(MethodInfo registerMethod, string name, Func<object, string> provider, string description, int priority)
+        {
+            try
+            {
+                registerMethod.Invoke(null, new object[] { MOD_ID, name, provider, description, priority });
+                if (Prefs.DevMode)
+                {
+                    Log.Message($"[MemoryPatch] ✓ Registered {{{{{name}}}}} variable");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning($"[MemoryPatch] Failed to register {name}: {ex.Message}");
+            }
+        }
         
         /// <summary>
         /// 注册 PromptEntry
@@ -345,7 +241,6 @@ namespace RimTalk.Memory.API
         /// - 必须先设置 SourceModId 再设置 Name（因为 Name setter 会触发 ID 更新）
         /// - ID 会自动生成为 mod_{sanitized_mod_id}_{sanitized_name}
         /// ⭐ v4.1: 支持更新现有条目内容，无需重置默认
-        /// ⭐ v5.0: 在 Chat History 条目后插入，并自动禁用 Chat History
         /// </summary>
         private static void RegisterPromptEntry()
         {
@@ -356,10 +251,9 @@ namespace RimTalk.Memory.API
                 
                 // 获取 ActivePreset
                 var getPresetMethod = _promptAPIType.GetMethod("GetActivePreset");
-                object preset = null;
                 if (getPresetMethod != null)
                 {
-                    preset = getPresetMethod.Invoke(null, null);
+                    var preset = getPresetMethod.Invoke(null, null);
                     if (preset != null)
                     {
                         // 尝试获取现有条目
@@ -372,9 +266,6 @@ namespace RimTalk.Memory.API
                                 // ⭐ 条目已存在 → 直接更新 Content
                                 SetProperty(existingEntry, "Content", GetMemoryEntryContent());
                                 Log.Message($"[MemoryPatch] ✓ Updated existing PromptEntry: {ENTRY_NAME}");
-                                
-                                // ⭐ v5.0: 仍然检查并禁用 Chat History
-                                DisableChatHistoryIfEnabled(preset);
                                 return;
                             }
                         }
@@ -401,7 +292,7 @@ namespace RimTalk.Memory.API
                 // 设置 Role = System
                 if (_promptRoleType != null)
                 {
-                    var systemRole = Enum.Parse(_promptRoleType, "System");
+                    var systemRole = Enum.Parse(_promptRoleType, "User");
                     SetProperty(entry, "Role", systemRole);
                 }
                 
@@ -412,40 +303,25 @@ namespace RimTalk.Memory.API
                     SetProperty(entry, "Position", relativePos);
                 }
                 
-                // ⭐ v5.0: 在 Chat History 条目后插入（而不是添加到末尾）
-                var insertAfterNameMethod = _promptAPIType.GetMethod("InsertPromptEntryAfterName");
-                if (insertAfterNameMethod != null)
+                // 添加到 Preset 末尾
+                // ⭐ 新 API 会自动去重：如果已存在相同 ID 的条目，会返回 false
+                var addMethod = _promptAPIType.GetMethod("AddPromptEntry");
+                if (addMethod != null)
                 {
-                    var result = insertAfterNameMethod.Invoke(null, new object[] { entry, CHAT_HISTORY_ENTRY_NAME });
+                    var result = addMethod.Invoke(null, new[] { entry });
                     if (result is bool success)
                     {
                         if (success)
                         {
-                            Log.Message($"[MemoryPatch] ✓ Inserted PromptEntry after '{CHAT_HISTORY_ENTRY_NAME}': {ENTRY_NAME}");
+                            Log.Message($"[MemoryPatch] ✓ Added PromptEntry: {ENTRY_NAME}");
                         }
                         else
                         {
-                            // Chat History 未找到，已添加到末尾
-                            Log.Message($"[MemoryPatch] ✓ Added PromptEntry at end ('{CHAT_HISTORY_ENTRY_NAME}' not found): {ENTRY_NAME}");
-                        }
-                        
-                        // ⭐ v5.0: 禁用 Chat History
-                        if (preset != null)
-                        {
-                            DisableChatHistoryIfEnabled(preset);
-                        }
-                    }
-                }
-                else
-                {
-                    // 回退：使用旧的 AddPromptEntry 方法
-                    var addMethod = _promptAPIType.GetMethod("AddPromptEntry");
-                    if (addMethod != null)
-                    {
-                        var result = addMethod.Invoke(null, new[] { entry });
-                        if (result is bool success && success)
-                        {
-                            Log.Message($"[MemoryPatch] ✓ Added PromptEntry: {ENTRY_NAME}");
+                            // 返回 false 可能是因为被用户删除（在黑名单中）
+                            if (Prefs.DevMode)
+                            {
+                                Log.Message($"[MemoryPatch] PromptEntry blacklisted by user: {ENTRY_NAME}");
+                            }
                         }
                     }
                 }
@@ -457,107 +333,20 @@ namespace RimTalk.Memory.API
         }
         
         /// <summary>
-        /// ⭐ v5.0: 检查并禁用 Chat History 条目（如果它是开启的）
-        /// 这样可以避免与我们的记忆系统冲突
-        /// </summary>
-        private static void DisableChatHistoryIfEnabled(object preset)
-        {
-            try
-            {
-                if (preset == null) return;
-                
-                // 查找 Chat History 条目
-                var findEntryByNameMethod = preset.GetType().GetMethod("FindEntryIdByName");
-                if (findEntryByNameMethod == null)
-                {
-                    if (Prefs.DevMode) Log.Warning("[MemoryPatch] FindEntryIdByName method not found");
-                    return;
-                }
-                
-                var chatHistoryId = findEntryByNameMethod.Invoke(preset, new object[] { CHAT_HISTORY_ENTRY_NAME }) as string;
-                if (string.IsNullOrEmpty(chatHistoryId))
-                {
-                    if (Prefs.DevMode) Log.Message($"[MemoryPatch] '{CHAT_HISTORY_ENTRY_NAME}' entry not found in preset");
-                    return;
-                }
-                
-                var getEntryMethod = preset.GetType().GetMethod("GetEntry");
-                if (getEntryMethod == null)
-                {
-                    if (Prefs.DevMode) Log.Warning("[MemoryPatch] GetEntry method not found");
-                    return;
-                }
-                
-                var chatHistoryEntry = getEntryMethod.Invoke(preset, new object[] { chatHistoryId });
-                if (chatHistoryEntry == null)
-                {
-                    if (Prefs.DevMode) Log.Warning("[MemoryPatch] Chat History entry is null");
-                    return;
-                }
-                
-                // ⭐ 修复：Enabled 是字段（field），不是属性（property）
-                // 先尝试属性，如果没有则尝试字段
-                var enabledProp = chatHistoryEntry.GetType().GetProperty("Enabled");
-                var enabledField = chatHistoryEntry.GetType().GetField("Enabled");
-                
-                bool isEnabled = false;
-                if (enabledProp != null)
-                {
-                    isEnabled = (bool)enabledProp.GetValue(chatHistoryEntry);
-                }
-                else if (enabledField != null)
-                {
-                    isEnabled = (bool)enabledField.GetValue(chatHistoryEntry);
-                }
-                else
-                {
-                    if (Prefs.DevMode) Log.Warning("[MemoryPatch] Enabled property/field not found on PromptEntry");
-                    return;
-                }
-                
-                if (isEnabled)
-                {
-                    // 禁用 Chat History
-                    if (enabledProp != null)
-                    {
-                        enabledProp.SetValue(chatHistoryEntry, false);
-                    }
-                    else if (enabledField != null)
-                    {
-                        enabledField.SetValue(chatHistoryEntry, false);
-                    }
-                    Log.Message($"[MemoryPatch] ✓ Disabled '{CHAT_HISTORY_ENTRY_NAME}' to avoid conflict with Memory & Knowledge injection");
-                }
-                else
-                {
-                    if (Prefs.DevMode) Log.Message($"[MemoryPatch] '{CHAT_HISTORY_ENTRY_NAME}' is already disabled");
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Warning($"[MemoryPatch] Failed to disable Chat History: {ex.Message}");
-                if (Prefs.DevMode)
-                {
-                    Log.Warning($"[MemoryPatch] Stack trace: {ex.StackTrace}");
-                }
-            }
-        }
-        
-        /// <summary>
         /// 获取 Memory Entry 的模板内容
         /// </summary>
         private static string GetMemoryEntryContent()
         {
             return @"---
-# Memory Context
-{{-for p in pawns }}
-## {{ p.name }}'s Memories:
-{{ p.memory }}
-{{- end }}
 
-# World Knowledge:
-{{knowledge}}
----";
+## Memory & Knowledge Context
+
+
+### {{pawn.name}}'s Memories:
+{{pawn.memory}}
+
+### World Knowledge:
+{{knowledge}}";
         }
         
         /// <summary>

--- a/Source/Memory/UI/CommonKnowledgeUIHelpers.cs
+++ b/Source/Memory/UI/CommonKnowledgeUIHelpers.cs
@@ -70,11 +70,16 @@ namespace RimTalk.Memory.UI
         
         /// <summary>
         /// 根据标签判断条目分类
-        /// ⭐ 新规则：只要标签中包含分类关键词，即归入该分类
-        /// 例如："规则-世界观"、"常识规则"、"规则，鼠族" 都归入"规则"分类
+        /// ⭐ 优先使用显式分类（用户在UI中选择的），未设置时回退到标签关键词推断
         /// </summary>
         public static KnowledgeCategory GetEntryCategory(CommonKnowledgeEntry entry)
         {
+            // ⭐ 优先使用显式分类
+            if (entry.category != KnowledgeEntryCategory.None)
+            {
+                return ExplicitCategoryToKnowledgeCategory(entry.category);
+            }
+            
             if (string.IsNullOrEmpty(entry.tag))
                 return KnowledgeCategory.Other;
 
@@ -116,6 +121,55 @@ namespace RimTalk.Memory.UI
             return KnowledgeCategory.Other;
         }
         
+        /// <summary>
+        /// 将显式分类枚举转换为 UI 分类枚举
+        /// </summary>
+        public static KnowledgeCategory ExplicitCategoryToKnowledgeCategory(KnowledgeEntryCategory cat)
+        {
+            switch (cat)
+            {
+                case KnowledgeEntryCategory.Instructions: return KnowledgeCategory.Instructions;
+                case KnowledgeEntryCategory.Lore: return KnowledgeCategory.Lore;
+                case KnowledgeEntryCategory.PawnStatus: return KnowledgeCategory.PawnStatus;
+                case KnowledgeEntryCategory.History: return KnowledgeCategory.History;
+                case KnowledgeEntryCategory.Other: return KnowledgeCategory.Other;
+                default: return KnowledgeCategory.Other;
+            }
+        }
+        
+        /// <summary>
+        /// 将 UI 分类枚举转换为显式分类枚举
+        /// </summary>
+        public static KnowledgeEntryCategory KnowledgeCategoryToExplicit(KnowledgeCategory cat)
+        {
+            switch (cat)
+            {
+                case KnowledgeCategory.Instructions: return KnowledgeEntryCategory.Instructions;
+                case KnowledgeCategory.Lore: return KnowledgeEntryCategory.Lore;
+                case KnowledgeCategory.PawnStatus: return KnowledgeEntryCategory.PawnStatus;
+                case KnowledgeCategory.History: return KnowledgeEntryCategory.History;
+                case KnowledgeCategory.Other: return KnowledgeEntryCategory.Other;
+                default: return KnowledgeEntryCategory.None;
+            }
+        }
+        
+        /// <summary>
+        /// 获取显式分类的中文显示名称
+        /// </summary>
+        public static string GetExplicitCategoryLabel(KnowledgeEntryCategory cat)
+        {
+            switch (cat)
+            {
+                case KnowledgeEntryCategory.None: return "自动推断";
+                case KnowledgeEntryCategory.Instructions: return "指令规则";
+                case KnowledgeEntryCategory.Lore: return "世界观设定";
+                case KnowledgeEntryCategory.PawnStatus: return "殖民者状态";
+                case KnowledgeEntryCategory.History: return "历史记录";
+                case KnowledgeEntryCategory.Other: return "其他";
+                default: return "未知";
+            }
+        }
+        
         // ==================== 可见性相关 ====================
         
         /// <summary>
@@ -146,12 +200,22 @@ namespace RimTalk.Memory.UI
             
             Text.Font = GameFont.Tiny;
             GUI.color = new Color(0.7f, 0.7f, 0.7f);
-            Widgets.Label(new Rect(rect.x, rect.y, labelWidth, rect.height), label + ":");
+            Widgets.Label(new Rect(rect.x, rect.y, labelWidth, rect.height), EnsureColon(label));
             GUI.color = Color.white;
             Text.Font = GameFont.Small;
             
             Widgets.Label(new Rect(rect.x + labelWidth, rect.y, rect.width - labelWidth, rect.height), value);
         }
+
+        /// <summary>
+        /// 确保标签文本以冒号结尾（兼容不同语言翻译文件中冒号有无不一致的情况）
+        /// </summary>
+        public static string EnsureColon(string label)
+        {
+            if (string.IsNullOrEmpty(label)) return ":";
+            return label.EndsWith(":") || label.EndsWith("：") ? label : label + ":";
+        }
+
         
         // ==================== 绘制带颜色的复选框 ====================
         

--- a/Source/Memory/UI/Dialog_CommonKnowledge.cs
+++ b/Source/Memory/UI/Dialog_CommonKnowledge.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -23,8 +23,16 @@ namespace RimTalk.Memory.UI
         
         // Drag selection
         private bool isDragging = false;
+        private bool isMouseDown = false;           // ⭐ 左键已按下但尚未判定为拖拽
         private Vector2 dragStartPos = Vector2.zero;
         private Vector2 dragCurrentPos = Vector2.zero;
+        private Vector2 mouseDownScreenPos = Vector2.zero; // ⭐ 按下时的屏幕坐标（用于阈值判定）
+        private const float DRAG_THRESHOLD = 5f;    // ⭐ 拖拽判定阈值（像素）
+        
+        // ⭐ 拖拽排序
+        private bool isDragReordering = false;      // 是否处于拖拽排序模式
+        private int dragReorderInsertIndex = -1;    // 插入位置索引
+        private bool mouseDownOnSelected = false;   // 按下时是否在已选中条目上
         
         // UI State
         private Vector2 listScrollPosition = Vector2.zero;
@@ -48,6 +56,7 @@ namespace RimTalk.Memory.UI
         private float editImportance = 0.5f;
         private int editTargetPawnId = -1;
         private KeywordMatchMode editMatchMode = KeywordMatchMode.Any;
+        private KnowledgeEntryCategory editCategory = KnowledgeEntryCategory.None;
         
         // Layout constants
         private const float TOOLBAR_HEIGHT = 45f;
@@ -109,9 +118,49 @@ namespace RimTalk.Memory.UI
             }
             
             // Handle input events (must be after all UI drawing)
-            if (Event.current.type == EventType.MouseUp && isDragging)
+            if (Event.current.type == EventType.MouseUp && Event.current.button == 0)
             {
+                if (isMouseDown && isDragReordering && dragReorderInsertIndex >= 0)
+                {
+                    // ⭐ 拖拽排序完成：将选中条目移动到目标位置
+                    ExecuteDragReorder();
+                }
+                else if (isMouseDown && !isDragging)
+                {
+                    // ⭐ 没有进入拖拽模式 → 当作单击处理
+                    // 找到鼠标下方的条目
+                    float centerX2 = SIDEBAR_WIDTH + SPACING;
+                    float centerWidth2 = showRightPanel ? 
+                        (inRect.width - SIDEBAR_WIDTH - RIGHT_PANEL_WIDTH - SPACING * 3) : 
+                        (inRect.width - SIDEBAR_WIDTH - SPACING * 2);
+                    Rect centerRect2 = new Rect(centerX2, contentY, centerWidth2, contentHeight);
+                    Rect innerRect2 = centerRect2.ContractedBy(5f);
+                    
+                    if (innerRect2.Contains(Event.current.mousePosition))
+                    {
+                        // 转换为 content 坐标
+                        float mouseContentY = Event.current.mousePosition.y - innerRect2.y + listScrollPosition.y;
+                        var filteredEntries2 = GetFilteredEntries();
+                        int clickedIndex = (int)(mouseContentY / ENTRY_HEIGHT);
+                        
+                        if (clickedIndex >= 0 && clickedIndex < filteredEntries2.Count)
+                        {
+                            HandleEntryClick(filteredEntries2[clickedIndex]);
+                        }
+                        else
+                        {
+                            // 点击空白区域，清除选择
+                            selectedEntries.Clear();
+                            lastSelectedEntry = null;
+                        }
+                    }
+                }
+                
+                isMouseDown = false;
                 isDragging = false;
+                isDragReordering = false;
+                dragReorderInsertIndex = -1;
+                mouseDownOnSelected = false;
                 Event.current.Use();
             }
         }
@@ -357,10 +406,21 @@ namespace RimTalk.Memory.UI
                 y += ENTRY_HEIGHT;
             }
             
-            // ⭐ 修复：在EndScrollView之前绘制选择框
+            // ⭐ 修复：在EndScrollView之前绘制选择框或拖拽排序指示线
             if (isDragging)
             {
                 DrawSelectionBox();
+            }
+            else if (isDragReordering && dragReorderInsertIndex >= 0)
+            {
+                // ⭐ 绘制拖拽排序的插入指示线
+                float insertY = dragReorderInsertIndex * ENTRY_HEIGHT;
+                Rect lineRect = new Rect(0f, insertY - 2f, viewRect.width, 4f);
+                Widgets.DrawBoxSolid(lineRect, new Color(0.3f, 0.8f, 1f, 0.8f));
+                
+                // 绘制小三角指示
+                Rect arrowRect = new Rect(-2f, insertY - 6f, 12f, 12f);
+                Widgets.DrawBoxSolid(arrowRect, new Color(0.3f, 0.8f, 1f, 0.9f));
             }
             
             Widgets.EndScrollView();
@@ -398,11 +458,8 @@ namespace RimTalk.Memory.UI
                 Widgets.DrawLightHighlight(rect);
             }
             
-            // Handle click (without drag)
-            if (Widgets.ButtonInvisible(rect) && !isDragging)
-            {
-                HandleEntryClick(entry);
-            }
+            // ⭐ 点击选择现在由 DoWindowContents 的 MouseUp 统一处理
+            // 不再使用 ButtonInvisible（它会和拖拽框选冲突）
             
             Rect innerRect = rect.ContractedBy(5f);
             float x = innerRect.x;
@@ -531,6 +588,79 @@ namespace RimTalk.Memory.UI
                 editMode = false;
             }
         }
+
+        /// <summary>
+        /// 执行拖拽排序：将选中的条目移动到 dragReorderInsertIndex 位置
+        /// 操作的是 library.Entries（主列表），不是 filteredEntries
+        /// </summary>
+        private void ExecuteDragReorder()
+        {
+            var filteredEntries = GetFilteredEntries();
+            if (filteredEntries.Count == 0 || selectedEntries.Count == 0) return;
+            
+            // 1. 确定插入目标在主列表中的位置
+            int targetMainIndex;
+            if (dragReorderInsertIndex >= filteredEntries.Count)
+            {
+                // 插入到末尾：找到最后一个过滤条目在主列表中的位置之后
+                var lastFiltered = filteredEntries[filteredEntries.Count - 1];
+                targetMainIndex = library.Entries.IndexOf(lastFiltered) + 1;
+            }
+            else if (dragReorderInsertIndex <= 0)
+            {
+                // 插入到开头：找到第一个过滤条目在主列表中的位置
+                var firstFiltered = filteredEntries[0];
+                targetMainIndex = library.Entries.IndexOf(firstFiltered);
+            }
+            else
+            {
+                // 插入到中间：找到目标位置条目在主列表中的位置
+                var targetEntry = filteredEntries[dragReorderInsertIndex];
+                targetMainIndex = library.Entries.IndexOf(targetEntry);
+            }
+            
+            // 2. 收集选中的条目（保持原有顺序）
+            var entriesToMove = new List<CommonKnowledgeEntry>();
+            foreach (var entry in library.Entries)
+            {
+                if (selectedEntries.Contains(entry))
+                {
+                    entriesToMove.Add(entry);
+                }
+            }
+            
+            if (entriesToMove.Count == 0) return;
+            
+            // 3. 从主列表中移除选中的条目
+            foreach (var entry in entriesToMove)
+            {
+                library.Entries.Remove(entry);
+            }
+            
+            // 4. 重新计算插入位置（因为移除了条目，索引可能变化）
+            // 找到目标位置：如果目标条目还在列表中，插入到它前面
+            if (dragReorderInsertIndex < filteredEntries.Count)
+            {
+                var targetEntry = filteredEntries[dragReorderInsertIndex];
+                int newIdx = library.Entries.IndexOf(targetEntry);
+                if (newIdx >= 0)
+                {
+                    targetMainIndex = newIdx;
+                }
+                else
+                {
+                    targetMainIndex = library.Entries.Count;
+                }
+            }
+            else
+            {
+                targetMainIndex = library.Entries.Count;
+            }
+            
+            // 5. 在目标位置插入
+            targetMainIndex = Mathf.Clamp(targetMainIndex, 0, library.Entries.Count);
+            library.Entries.InsertRange(targetMainIndex, entriesToMove);
+        }
         
         private void DrawSelectionBox()
         {
@@ -549,58 +679,105 @@ namespace RimTalk.Memory.UI
             return new Rect(minX, minY, maxX - minX, maxY - minY);
         }
         
-        // ⭐ 新方法：处理拖拽事件（不绘制选择框）
+        // ⭐ 重写：鼠标事件处理（左键点选 + 拖拽框选共存）
+        // MouseDown → 记录起始位置，不吞事件
+        // MouseDrag → 超过阈值才进入框选模式
+        // MouseUp → 未进入框选则当作单击
         private void HandleDragSelectionEvents(Rect listRect, Rect viewRect)
         {
             Event e = Event.current;
-            
-            // 开始拖拽
+
+            // 左键按下：记录起始位置，判断是否在已选中条目上
             if (e.type == EventType.MouseDown && e.button == 0 && listRect.Contains(e.mousePosition))
             {
-                isDragging = true;
-                // 转换为viewport坐标
+                isMouseDown = true;
+                mouseDownScreenPos = e.mousePosition;
                 dragStartPos = e.mousePosition - listRect.position;
                 dragCurrentPos = dragStartPos;
-                e.Use();
-            }
-            
-            // 拖拽中
-            if (isDragging && e.type == EventType.MouseDrag)
-            {
-                dragCurrentPos = e.mousePosition - listRect.position;
-                
-                // 转换为content坐标
-                Rect selectionBoxViewport = GetSelectionBox();
-                Rect selectionBoxContent = new Rect(
-                    selectionBoxViewport.x,
-                    selectionBoxViewport.y + listScrollPosition.y,
-                    selectionBoxViewport.width,
-                    selectionBoxViewport.height
-                );
-                
+
+                // ⭐ 判断按下位置是否在已选中的条目上
+                Vector2 localPos = e.mousePosition - listRect.position;
+                float mouseContentY = localPos.y + listScrollPosition.y;
                 var filteredEntries = GetFilteredEntries();
-                
-                bool ctrl = Event.current.control;
-                if (!ctrl)
+                int clickedIdx = (int)(mouseContentY / ENTRY_HEIGHT);
+
+                mouseDownOnSelected = false;
+                if (clickedIdx >= 0 && clickedIdx < filteredEntries.Count)
                 {
-                    selectedEntries.Clear();
+                    mouseDownOnSelected = selectedEntries.Contains(filteredEntries[clickedIdx]);
                 }
-                
-                // 检查哪些条目在选择框内
-                float y = 0f;
-                foreach (var entry in filteredEntries)
+            }
+
+            // 鼠标移动中：判断是否超过拖拽阈值
+            if (isMouseDown && e.type == EventType.MouseDrag && e.button == 0)
+            {
+                float distance = Vector2.Distance(mouseDownScreenPos, e.mousePosition);
+
+                if (!isDragging && !isDragReordering && distance >= DRAG_THRESHOLD)
                 {
-                    Rect entryRect = new Rect(0f, y, viewRect.width, ENTRY_HEIGHT);
-                    
-                    if (selectionBoxContent.Overlaps(entryRect))
+                    if (mouseDownOnSelected && selectedEntries.Count > 0)
                     {
-                        selectedEntries.Add(entry);
+                        // ⭐ 在已选中条目上拖拽 → 拖拽排序模式
+                        isDragReordering = true;
                     }
-                    
-                    y += ENTRY_HEIGHT;
+                    else
+                    {
+                        // ⭐ 在未选中区域拖拽 → 框选模式
+                        isDragging = true;
+                    }
                 }
-                
-                e.Use();
+
+                if (isDragReordering)
+                {
+                    // ⭐ 拖拽排序：计算插入位置
+                    Vector2 localMousePos = e.mousePosition - listRect.position;
+                    float contentMouseY = localMousePos.y + listScrollPosition.y;
+                    var filteredEntries = GetFilteredEntries();
+
+                    // 计算最近的插入线位置（在条目之间）
+                    dragReorderInsertIndex = Mathf.Clamp(
+                        Mathf.RoundToInt(contentMouseY / ENTRY_HEIGHT),
+                        0, filteredEntries.Count);
+
+                    e.Use();
+                }
+                else if (isDragging)
+                {
+                    dragCurrentPos = e.mousePosition - listRect.position;
+
+                    // 转换为content坐标
+                    Rect selectionBoxViewport = GetSelectionBox();
+                    Rect selectionBoxContent = new Rect(
+                        selectionBoxViewport.x,
+                        selectionBoxViewport.y + listScrollPosition.y,
+                        selectionBoxViewport.width,
+                        selectionBoxViewport.height
+                    );
+
+                    var filteredEntries = GetFilteredEntries();
+
+                    bool ctrl = Event.current.control;
+                    if (!ctrl)
+                    {
+                        selectedEntries.Clear();
+                    }
+
+                    // 检查哪些条目在选择框内
+                    float y = 0f;
+                    foreach (var entry in filteredEntries)
+                    {
+                        Rect entryRect = new Rect(0f, y, viewRect.width, ENTRY_HEIGHT);
+
+                        if (selectionBoxContent.Overlaps(entryRect))
+                        {
+                            selectedEntries.Add(entry);
+                        }
+
+                        y += ENTRY_HEIGHT;
+                    }
+
+                    e.Use();
+                }
             }
         }
 
@@ -772,6 +949,18 @@ namespace RimTalk.Memory.UI
             );
             scrollY += 55f;
             
+            // ⭐ Category
+            var entryCat = CommonKnowledgeUIHelpers.GetEntryCategory(entry);
+            string catDisplay = CommonKnowledgeUIHelpers.GetCategoryLabel(entryCat);
+            if (entry.category == KnowledgeEntryCategory.None)
+                catDisplay += " (自动)";
+            CommonKnowledgeUIHelpers.DrawDetailField(
+                new Rect(0f, scrollY, scrollViewRect.width, 25f),
+                "分类",
+                catDisplay
+            );
+            scrollY += 30f;
+            
             // Importance
             CommonKnowledgeUIHelpers.DrawDetailField(
                 new Rect(0f, scrollY, scrollViewRect.width, 25f), 
@@ -872,13 +1061,38 @@ namespace RimTalk.Memory.UI
             
             // Tag
             Widgets.Label(new Rect(rect.x, y, 100f, 25f), 
-                CommonKnowledgeTranslationKeys.Tag.Translate() + ":");
+                CommonKnowledgeUIHelpers.EnsureColon(CommonKnowledgeTranslationKeys.Tag.Translate()));
             editTag = Widgets.TextField(new Rect(rect.x + 100f, y, rect.width - 100f, 25f), editTag);
+            y += 30f;
+            
+            // ⭐ Category dropdown (after tag)
+            Widgets.Label(new Rect(rect.x, y, 100f, 25f), "分类:");
+            string catLabel = CommonKnowledgeUIHelpers.GetExplicitCategoryLabel(editCategory);
+            // 显示推断提示
+            if (editCategory == KnowledgeEntryCategory.None && !string.IsNullOrEmpty(editTag))
+            {
+                var inferred = CommonKnowledgeUIHelpers.GetEntryCategory(
+                    new CommonKnowledgeEntry(editTag, "") { category = KnowledgeEntryCategory.None });
+                string inferredName = CommonKnowledgeUIHelpers.GetCategoryLabel(inferred);
+                catLabel = "自动推断 → " + inferredName;
+            }
+            if (Widgets.ButtonText(new Rect(rect.x + 100f, y, rect.width - 100f, 25f), catLabel))
+            {
+                List<FloatMenuOption> options = new List<FloatMenuOption>();
+                foreach (KnowledgeEntryCategory cat in Enum.GetValues(typeof(KnowledgeEntryCategory)))
+                {
+                    KnowledgeEntryCategory localCat = cat;
+                    options.Add(new FloatMenuOption(
+                        CommonKnowledgeUIHelpers.GetExplicitCategoryLabel(cat),
+                        delegate { editCategory = localCat; }));
+                }
+                Find.WindowStack.Add(new FloatMenu(options));
+            }
             y += 30f;
             
             // Importance
             Widgets.Label(new Rect(rect.x, y, 100f, 25f), 
-                CommonKnowledgeTranslationKeys.Importance.Translate() + ":");
+                CommonKnowledgeUIHelpers.EnsureColon(CommonKnowledgeTranslationKeys.Importance.Translate()));
             editImportance = Widgets.HorizontalSlider(
                 new Rect(rect.x + 100f, y, rect.width - 150f, 25f), 
                 editImportance, 0f, 1f
@@ -888,7 +1102,7 @@ namespace RimTalk.Memory.UI
             
             // Pawn selection (simplified)
             Widgets.Label(new Rect(rect.x, y, 100f, 25f), 
-                CommonKnowledgeTranslationKeys.Visibility.Translate() + ":");
+                CommonKnowledgeUIHelpers.EnsureColon(CommonKnowledgeTranslationKeys.Visibility.Translate()));
             string pawnLabel = editTargetPawnId == -1 
                 ? CommonKnowledgeTranslationKeys.Global.Translate().ToString() 
                 : $"Pawn #{editTargetPawnId}";
@@ -914,7 +1128,7 @@ namespace RimTalk.Memory.UI
             
             // Content
             Widgets.Label(new Rect(rect.x, y, 100f, 25f), 
-                CommonKnowledgeTranslationKeys.Content.Translate() + ":");
+                CommonKnowledgeUIHelpers.EnsureColon(CommonKnowledgeTranslationKeys.Content.Translate()));
             y += 27f;
             
             float contentHeight = rect.yMax - y - 80f;
@@ -1019,6 +1233,7 @@ namespace RimTalk.Memory.UI
             editImportance = 0.5f;
             editTargetPawnId = -1;
             editMatchMode = KeywordMatchMode.Any;
+            editCategory = KnowledgeEntryCategory.None;
             lastSelectedEntry = null;
             selectedEntries.Clear();
             editMode = true;
@@ -1034,6 +1249,7 @@ namespace RimTalk.Memory.UI
                 editImportance = entry.importance;
                 editTargetPawnId = entry.targetPawnId;
                 editMatchMode = entry.matchMode;
+                editCategory = entry.category;
                 lastSelectedEntry = entry;
                 editMode = true;
             }
@@ -1056,7 +1272,8 @@ namespace RimTalk.Memory.UI
                     importance = editImportance,
                     targetPawnId = editTargetPawnId,
                     isUserEdited = true,  // ⭐ 新创建的条目标记为用户编辑
-                    matchMode = editMatchMode
+                    matchMode = editMatchMode,
+                    category = editCategory
                 };
                 library.AddEntry(newEntry);
                 selectedEntries.Clear();
@@ -1073,6 +1290,7 @@ namespace RimTalk.Memory.UI
                 // ⭐ 移除：不再每次保存都设置 isUserEdited = true
                 // lastSelectedEntry.isUserEdited = true;
                 lastSelectedEntry.matchMode = editMatchMode;
+                lastSelectedEntry.category = editCategory;
                 
                 // 清除缓存，确保新标签生效
                 lastSelectedEntry.InvalidateCache();

--- a/Source/Memory/UI/MainTabWindow_Memory.cs
+++ b/Source/Memory/UI/MainTabWindow_Memory.cs
@@ -38,8 +38,11 @@ namespace RimTalk.Memory.UI
         
         // Drag selection
         private bool isDragging = false;
+        private bool isMouseDown = false;           // ⭐ 左键已按下但尚未判定为拖拽
         private Vector2 dragStartPos = Vector2.zero;
         private Vector2 dragCurrentPos = Vector2.zero;
+        private Vector2 mouseDownScreenPos = Vector2.zero; // ⭐ 按下时的屏幕坐标（用于阈值判定）
+        private const float DRAG_THRESHOLD = 5f;    // ⭐ 拖拽判定阈值（像素）
         
         // UI State
         private Vector2 timelineScrollPosition = Vector2.zero;
@@ -54,7 +57,7 @@ namespace RimTalk.Memory.UI
         // ? v3.3.32: Filtered memories cache
         private List<MemoryEntry> cachedFilteredMemories;
         private bool filtersDirty = true;
-
+        
         // Layout constants
         private const float TOP_BAR_HEIGHT = 50f;
         private const float CONTROL_PANEL_WIDTH = 220f;
@@ -79,16 +82,6 @@ namespace RimTalk.Memory.UI
         private int lastRefreshTick = -1;
         
         public override Vector2 RequestedTabSize => new Vector2(1200f, 700f);
-
-        /// <summary>
-        /// 使 UI 缓存失效，强制下次绘制时刷新。
-        /// 当外部修改了记忆数据时调用此方法。
-        /// </summary>
-        public void InvalidateCache()
-        {
-            lastMemoryCount = -1;
-            filtersDirty = true;
-        }
 
         // ==================== Main Layout ====================
         
@@ -130,9 +123,48 @@ namespace RimTalk.Memory.UI
             Rect timelineRect = new Rect(timelineX, contentY, timelineWidth, contentHeight);
             DrawTimeline(timelineRect);
             
-            // Handle drag end
-            if (Event.current.type == EventType.MouseUp && isDragging)
+            // Handle drag end / single click
+            if (Event.current.type == EventType.MouseUp && Event.current.button == 0)
             {
+                if (isMouseDown && !isDragging)
+                {
+                    // ⭐ 没有进入拖拽模式 → 当作单击处理
+                    // 找到鼠标下方的记忆卡片
+                    float timelineX2 = CONTROL_PANEL_WIDTH + SPACING;
+                    float timelineWidth2 = inRect.width - timelineX2;
+                    Rect timelineRect2 = new Rect(timelineX2, contentY, timelineWidth2, contentHeight);
+                    Rect innerRect2 = timelineRect2.ContractedBy(5f);
+                    
+                    if (innerRect2.Contains(Event.current.mousePosition))
+                    {
+                        float mouseContentY = Event.current.mousePosition.y - innerRect2.y + timelineScrollPosition.y;
+                        
+                        // 在缓存的 Y 位置中查找点击的卡片
+                        MemoryEntry clickedMemory = null;
+                        for (int i = 0; i < cachedMemories.Count; i++)
+                        {
+                            float cardY = cachedCardYPositions[i];
+                            float cardH = cachedCardHeights[i];
+                            if (mouseContentY >= cardY && mouseContentY < cardY + cardH)
+                            {
+                                clickedMemory = cachedMemories[i];
+                                break;
+                            }
+                        }
+                        
+                        if (clickedMemory != null)
+                        {
+                            HandleMemoryClick(clickedMemory);
+                        }
+                        else
+                        {
+                            selectedMemories.Clear();
+                            lastSelectedMemory = null;
+                        }
+                    }
+                }
+                
+                isMouseDown = false;
                 isDragging = false;
                 Event.current.Use();
             }

--- a/Source/Memory/UI/MainTabWindow_Memory_Timeline.cs
+++ b/Source/Memory/UI/MainTabWindow_Memory_Timeline.cs
@@ -193,12 +193,9 @@ namespace RimTalk.Memory.UI
             
             Rect innerRect = rect.ContractedBy(8f);
             
-            // ? 计算按钮区域（用于检测是否点击在按钮上）
+            // ? 计算按钮区域
             float buttonSize = 24f;
             float buttonSpacing = 4f;
-            float buttonAreaX = innerRect.xMax - (buttonSize * 2 + buttonSpacing + 8f);
-            Rect buttonAreaRect = new Rect(buttonAreaX, innerRect.y, buttonSize * 2 + buttonSpacing + 8f, buttonSize);
-            bool clickedOnButton = false;
             
             // Top-right action buttons
             float buttonX = innerRect.xMax - buttonSize;
@@ -218,7 +215,6 @@ namespace RimTalk.Memory.UI
                     currentMemoryComp.PinMemory(memory.id, memory.isPinned);
                 }
                 // ? v3.3.32: No need to mark dirty for pin/unpin as it doesn't affect filtering
-                clickedOnButton = true;
                 Event.current.Use();
             }
             TooltipHandler.TipRegion(pinButtonRect, memory.isPinned ? "RimTalk_MindStream_Unpin".Translate() : "RimTalk_MindStream_Pin".Translate());
@@ -239,16 +235,12 @@ namespace RimTalk.Memory.UI
                     // User might change layer or type which affects filtering
                     filtersDirty = true;
                 }
-                clickedOnButton = true;
                 Event.current.Use();
             }
             TooltipHandler.TipRegion(editButtonRect, "RimTalk_MindStream_Edit".Translate());
             
-            // ? 只在非按钮区域处理点击选择
-            if (!clickedOnButton && Widgets.ButtonInvisible(rect) && !isDragging && !buttonAreaRect.Contains(Event.current.mousePosition))
-            {
-                HandleMemoryClick(memory);
-            }
+            // ⭐ 点击选择现在由 DoWindowContents 的 MouseUp 统一处理
+            // 不再使用 ButtonInvisible（它会和拖拽框选冲突）
             
             // Content area (avoid button overlap)
             Rect contentRect = new Rect(innerRect.x, innerRect.y, innerRect.width - (buttonSize * 2 + buttonSpacing + 8f), innerRect.height);
@@ -353,60 +345,65 @@ namespace RimTalk.Memory.UI
         {
             Event e = Event.current;
             
-            // ? 修复：在viewport坐标系中开始拖拽
+            // 左键按下：记录起始位置
             if (e.type == EventType.MouseDown && e.button == 0 && listRect.Contains(e.mousePosition))
             {
-                isDragging = true;
-                // 转换为viewport坐标（相对于listRect）
+                isMouseDown = true;
+                mouseDownScreenPos = e.mousePosition;
                 dragStartPos = e.mousePosition - listRect.position;
                 dragCurrentPos = dragStartPos;
-                e.Use();
+                // ⭐ 不 Use 事件，不设 isDragging，等超过阈值再设
             }
             
-            if (isDragging && e.type == EventType.MouseDrag)
+            // 鼠标移动中：判断是否超过拖拽阈值
+            if (isMouseDown && e.type == EventType.MouseDrag && e.button == 0)
             {
-                // ? 修复：同样在viewport坐标系中
-                dragCurrentPos = e.mousePosition - listRect.position;
+                float distance = Vector2.Distance(mouseDownScreenPos, e.mousePosition);
                 
-                // Select memories that intersect with drag box
-                // ? 修复：转换为content坐标（加上scroll offset）
-                Rect selectionBoxViewport = GetSelectionBox();
-                Rect selectionBoxContent = new Rect(
-                    selectionBoxViewport.x, 
-                    selectionBoxViewport.y + timelineScrollPosition.y,
-                    selectionBoxViewport.width,
-                    selectionBoxViewport.height
-                );
-                
-                var filteredMemories = GetFilteredMemories();
-                
-                bool ctrl = Event.current.control;
-                if (!ctrl)
+                if (!isDragging && distance >= DRAG_THRESHOLD)
                 {
-                    selectedMemories.Clear();
+                    // 超过阈值，正式进入框选模式
+                    isDragging = true;
                 }
                 
-                float y = 0f;
-                foreach (var memory in filteredMemories)
+                if (isDragging)
                 {
-                    float height = GetCardHeight(memory.layer);
-                    Rect cardRect = new Rect(0f, y, viewRect.width, height);
+                    // ⭐ 在viewport坐标系中
+                    dragCurrentPos = e.mousePosition - listRect.position;
                     
-                    if (selectionBoxContent.Overlaps(cardRect))
+                    // 转换为content坐标（加上scroll offset）
+                    Rect selectionBoxViewport = GetSelectionBox();
+                    Rect selectionBoxContent = new Rect(
+                        selectionBoxViewport.x, 
+                        selectionBoxViewport.y + timelineScrollPosition.y,
+                        selectionBoxViewport.width,
+                        selectionBoxViewport.height
+                    );
+                    
+                    var filteredMemories = GetFilteredMemories();
+                    
+                    bool ctrl = Event.current.control;
+                    if (!ctrl)
                     {
-                        selectedMemories.Add(memory);
+                        selectedMemories.Clear();
                     }
                     
-                    y += height + CARD_SPACING;
+                    float y = 0f;
+                    foreach (var memory in filteredMemories)
+                    {
+                        float height = GetCardHeight(memory.layer);
+                        Rect cardRect = new Rect(0f, y, viewRect.width, height);
+                        
+                        if (selectionBoxContent.Overlaps(cardRect))
+                        {
+                            selectedMemories.Add(memory);
+                        }
+                        
+                        y += height + CARD_SPACING;
+                    }
+                    
+                    e.Use();
                 }
-                
-                e.Use();
-            }
-            
-            if (e.type == EventType.MouseUp && e.button == 0 && isDragging)
-            {
-                isDragging = false;
-                e.Use();
             }
         }
         


### PR DESCRIPTION
1. 常识分类变量扩展（API层）
   - 新增 7 个 Scriban 模板变量：knowledge_grouped/rules/lore/status/history/other
   - 复用 GetEntryCategory() 分类逻辑 + tick级缓存
   - {{knowledge}} 原有行为完全不变，旧预设零影响

2. 鼠标交互优化（常识页面 + 记忆页面）
   - 引入"按下→阈值→释放"三阶段鼠标模型，解决微小移动误判拖拽的问题
   - 常识页面新增拖拽排序功能
   - 移除 ButtonInvisible 冲突源

3. 编辑面板双冒号修复
   - 新增 EnsureColon() 方法，智能判断翻译值是否已含冒号
   - 全语言兼容，不修改任何翻译 XML
   - 分类下拉框移至标签字段之后

修改文件：
- Source/API/KnowledgeVariableProvider.cs
- Source/API/RimTalkAPIIntegration.cs
- Source/Memory/UI/Dialog_CommonKnowledge.cs
- Source/Memory/UI/CommonKnowledgeUIHelpers.cs
- Source/Memory/UI/MainTabWindow_Memory.cs
- Source/Memory/UI/MainTabWindow_Memory_Timeline.cs