### PR TITLE
基于玩家反馈，引入预设内容嗅探机制，智能防止记忆变量注入冲突

### DIFF
--- a/Docs/ContentSniffingPlan.md
+++ b/Docs/ContentSniffingPlan.md
@@ -1,0 +1,86 @@
+# Content Sniffing Implementation Plan
+
+## Background
+Currently, the `RimTalk-ExpandMemory` mod automatically injects a default `PromptEntry` containing memory and knowledge context into the active RimTalk preset. 
+However, when users switch to highly customized or advanced presets that already incorporate memory/knowledge variables (e.g., `{{pawn.memory}}` or `{{knowledge}}`), the automatic injection becomes redundant, leading to wasted tokens and potential AI confusion.
+
+## Objective
+Implement a "Content Heuristic Sniffing" mechanism. Before injecting the default entry, the mod will scan existing entries in the active preset. If it detects that the preset already uses memory or knowledge variables, it will safely abort the auto-injection process.
+
+## Target File
+`Source/API/RimTalkAPIIntegration.cs`
+
+## Implementation Details
+
+### 1. Define Sniffing Keywords
+We will define an array of critical substrings that indicate the preset is already handling memory/knowledge.
+```csharp
+private static readonly string[] SniffingKeywords = new string[]
+{
+    "pawn.memory", "p.memory",
+    "pawn.ABM", "p.ABM",
+    "pawn.ELS", "p.ELS",
+    "pawn.CLPA", "p.CLPA",
+    "{{knowledge}}", "{{ knowledge }}",
+    "knowledge_grouped", "knowledge_rules", 
+    "knowledge_lore", "knowledge_status", 
+    "knowledge_history"
+};
+```
+
+### 2. Modify `RegisterPromptEntry` Logic
+In the `RegisterPromptEntry` method, we will add a step to retrieve all entries from the `ActivePreset` and perform the sniffing scan.
+
+**Current Logic:**
+1. Get ActivePreset.
+2. Try to find the existing mod entry by deterministic ID.
+3. If found, update its content and return.
+4. If not found, create and insert the new entry.
+
+**New Logic:**
+1. Get ActivePreset.
+2. Try to find the existing mod entry by deterministic ID.
+3. If found, update its content and return.
+4. **[NEW]** If not found, retrieve the list of all existing entries (`Entries` property/field) from the ActivePreset.
+5. **[NEW]** Iterate through each entry's `Content` (ignoring null or empty strings).
+6. **[NEW]** Check if the `Content` contains any of the `SniffingKeywords`.
+7. **[NEW]** If a keyword is found, output a message (e.g., `"[MemoryPatch] Detected custom memory variables in active preset. Skipping auto-injection."`) and `return` to abort injection.
+8. If no keywords are found, proceed with creating and inserting the new entry as usual.
+
+### 3. Reflection Implementation for Compatibility
+Since RimTalk types are resolved via reflection (`_promptAPIType`, `_promptPresetType`, etc.), the sniffing logic must also use reflection to access the `Entries` list and the `Content` of each entry.
+
+```csharp
+// Example conceptual code for sniffing via reflection:
+var entriesField = preset.GetType().GetField("Entries");
+if (entriesField != null)
+{
+    var entriesList = entriesField.GetValue(preset) as System.Collections.IEnumerable;
+    if (entriesList != null)
+    {
+        foreach (var entry in entriesList)
+        {
+            var contentProp = entry.GetType().GetProperty("Content") ?? entry.GetType().GetField("Content");
+            string content = contentProp?.GetValue(entry) as string;
+            
+            if (!string.IsNullOrEmpty(content))
+            {
+                foreach (var keyword in SniffingKeywords)
+                {
+                    if (content.Contains(keyword))
+                    {
+                        // Match found, skip injection
+                        Log.Message($"[MemoryPatch] Detected custom memory variable '{keyword}' in preset. Skipping auto-injection.");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Benefits
+- **Zero Configuration:** Players do not need to manually toggle settings when switching between basic and advanced presets.
+- **High Compatibility:** Operates purely on string checking, agnostic to the specific structure or naming conventions of custom presets.
+- **Non-Destructive:** If the user removes the custom entries containing the variables, the mod will detect their absence upon the next restart and automatically provide the fallback default entry.

--- a/Source/API/RimTalkAPIIntegration.cs
+++ b/Source/API/RimTalkAPIIntegration.cs
@@ -1,5 +1,6 @@
 using RimTalk.API;
 using RimTalk.MemoryPatch;
+using RimTalk.Prompt;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -39,6 +40,19 @@ namespace RimTalk.Memory.API
         private static Type _promptRoleType;
         private static Type _promptPositionType;
         private static Type _promptContextType;  // ⭐ v5.0: 改名为 PromptContext
+        
+        // 用于嗅探预设是否已自定义记忆变量的关键词
+        private static readonly string[] SniffingKeywords = new string[]
+        {
+            "pawn.memory", "p.memory",
+            "pawn.ABM", "p.ABM",
+            "pawn.ELS", "p.ELS",
+            "pawn.CLPA", "p.CLPA",
+            "{{knowledge}}", "{{ knowledge }}",
+            "knowledge_grouped", "knowledge_rules", 
+            "knowledge_lore", "knowledge_status", 
+            "knowledge_history"
+        };
         
         // 标志：是否使用新 API（用于禁用旧 Patch）
         public static bool IsUsingNewAPI => _apiAvailable;
@@ -401,6 +415,31 @@ namespace RimTalk.Memory.API
                                 // ⭐ v5.0: 仍然检查并禁用 Chat History
                                 DisableChatHistoryIfEnabled(preset);
                                 return;
+                            }
+                        }
+                        
+                        // ⭐ 新增：内容特征嗅探 (Content Heuristic Sniffing)
+                        // 如果我们在预设中没有找到当前 Mod 注入的 Entry，
+                        // 我们扫描现有所有 Entry 的内容，判断预设是否已自行处理记忆上下文
+                        if (preset is PromptPreset rimtalkPreset)
+                        {
+                            if (rimtalkPreset.Entries != null)
+                            {
+                                foreach (var currentEntry in rimtalkPreset.Entries)
+                                {
+                                    string content = currentEntry.Content;
+                                    if (!string.IsNullOrEmpty(content))
+                                    {
+                                        foreach (var keyword in SniffingKeywords)
+                                        {
+                                            if (content.Contains(keyword))
+                                            {
+                                                Log.Message($"[MemoryPatch] Detected custom memory variable '{keyword}' in active preset. Skipping auto-injection.");
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
- 新增内容嗅探机制 (Content Heuristic Sniffing)：在自动注入默认记忆提示词前，扫描当前 RimTalk 激活预设中的所有条目。
- 智能放行：如果嗅探到预设内容中已包含 "pawn.memory", "{{knowledge}}" 等特征关键词，判定为高玩自定义预设，自动中止注入，避免 Token 浪费与 AI 幻觉。
- 引入零配置理念：玩家在切换基础预设和高级预设时，无需手动更改任何 Mod 设置，系统将根据内容特征自动适配。
- 新增 `ContentSniffingPlan.md` 设计文档，详细记录该机制的设计初衷与实现管线。