### PR TITLE
增加CreateInteraction Postfix实际执行的判断条件，以防止记忆重复

### DIFF
--- a/Source/Patches/Capture/TalkService_CreateInteraction_Patch.cs
+++ b/Source/Patches/Capture/TalkService_CreateInteraction_Patch.cs
@@ -19,6 +19,7 @@ namespace RimTalk.Memory.Patches.Capture
                 || talk is null
                 || ApiHistory.GetApiLog(talk.Id) is not { } apiLog
                 || apiLog.Channel is Channel.User   // 由玩家输入直接产生的那条 response 不处理
+                || apiLog.SpokenTick <= 0    // 防止因原方法被其他模组的 Prefix 阻断时仍将未实际生成的 response 加入记忆
                 || apiLog.TalkRequest is not { } talkRequest)   // talkRequest 即当前 response 的唯一标识
                 return;
 


### PR DESCRIPTION
经肘击群群友反馈若有其他prefix同方法的模组将CreateInteraction阻断，response仍会被TalkService_CreateInteraction_Patch拿到并加入记忆。这会导致一些问题，例如在TTS模组播放语音时持续阻断CreateInteraction，每次原方法试图执行时就会向记忆重复一遍发言内容。

添加了SpokenTick(被忽略=-1，等待=0，已说出=说出时的tick)过滤条件可以使一句发言真正说出来之后再加入记忆。